### PR TITLE
Fix return type for next_page_token method

### DIFF
--- a/src/frequenz/client/reporting/_client.py
+++ b/src/frequenz/client/reporting/_client.py
@@ -95,7 +95,7 @@ class ComponentsDataPage:
                     )
 
     @property
-    def next_page_token(self) -> Any:
+    def next_page_token(self) -> str | None:
         """Get the token for the next page of data.
 
         Returns:


### PR DESCRIPTION
From https://github.com/frequenz-floss/frequenz-client-reporting-python/pull/16#discussion_r1548118756