### PR TITLE
Rename ReportingClient to ReportingApiClient

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,8 @@
 
 ## Upgrading
 
+* The `ReportingClient` is renamed to `ReportingApiClient`.
+
 ## New Features
 
 ## Bug Fixes

--- a/examples/client.py
+++ b/examples/client.py
@@ -12,7 +12,7 @@ from typing import AsyncIterator
 import pandas as pd
 from frequenz.client.common.metric import Metric
 
-from frequenz.client.reporting import ReportingClient
+from frequenz.client.reporting import ReportingApiClient
 
 # Experimental import
 from frequenz.client.reporting._client import MetricSample
@@ -79,7 +79,7 @@ async def run(
     service_address: str,
     display: str,
 ) -> None:
-    """Test the ReportingClient.
+    """Test the ReportingApiClient.
 
     Args:
         microgrid_id: microgrid ID
@@ -94,7 +94,7 @@ async def run(
     Raises:
         ValueError: if display format is invalid
     """
-    client = ReportingClient(service_address)
+    client = ReportingApiClient(service_address)
 
     metrics = [Metric[mn] for mn in metric_names]
 

--- a/src/frequenz/client/reporting/__init__.py
+++ b/src/frequenz/client/reporting/__init__.py
@@ -7,6 +7,6 @@ This package provides a low-level interface for interacting with the reporting A
 """
 
 
-from ._client import ReportingClient
+from ._client import ReportingApiClient
 
-__all__ = ["ReportingClient"]
+__all__ = ["ReportingApiClient"]

--- a/src/frequenz/client/reporting/_client.py
+++ b/src/frequenz/client/reporting/_client.py
@@ -109,7 +109,7 @@ class ComponentsDataPage:
         return self._data_pb.pagination_info.next_page_token
 
 
-class ReportingClient:
+class ReportingApiClient:
     """A client for the Reporting service."""
 
     def __init__(self, service_address: str):
@@ -264,7 +264,7 @@ class ReportingClient:
         """Close the client and cancel any pending requests immediately."""
         await self._grpc_channel.close(grace=None)
 
-    async def __aenter__(self) -> "ReportingClient":
+    async def __aenter__(self) -> "ReportingApiClient":
         """Enter the async context."""
         return self
 

--- a/tests/test_client_reporting.py
+++ b/tests/test_client_reporting.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from frequenz.client.reporting import ReportingClient
+from frequenz.client.reporting import ReportingApiClient
 from frequenz.client.reporting._client import ComponentsDataPage
 
 
@@ -21,7 +21,7 @@ def mock_channel() -> Generator[MagicMock, None, None]:
 @pytest.mark.asyncio
 async def test_client_initialization(mock_channel: MagicMock) -> None:
     """Test that the client initializes the channel."""
-    client = ReportingClient("localhost:50051")  # noqa: F841
+    client = ReportingApiClient("localhost:50051")  # noqa: F841
     mock_channel.assert_called_once_with("localhost:50051")
 
 


### PR DESCRIPTION
From https://github.com/frequenz-floss/frequenz-client-reporting-python/pull/16#discussion_r1548122504