### PR TITLE
Remove iterator from function names

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,8 @@
 
 * The `ReportingClient` is renamed to `ReportingApiClient`.
 
+* The client method `iterate_single_component` is renamed to `list_single_component_data`.
+
 ## New Features
 
 ## Bug Fixes

--- a/examples/client.py
+++ b/examples/client.py
@@ -106,7 +106,7 @@ async def run(
         Returns:
             Iterator over single metric samples
         """
-        return client.iterate_single_component(
+        return client.list_single_component_data(
             microgrid_id=microgrid_id,
             component_id=component_id,
             metrics=metrics,

--- a/src/frequenz/client/reporting/_client.py
+++ b/src/frequenz/client/reporting/_client.py
@@ -122,7 +122,7 @@ class ReportingApiClient:
         self._stub = ReportingStub(self._grpc_channel)
 
     # pylint: disable=too-many-arguments
-    async def iterate_single_component(
+    async def list_single_component_data(
         self,
         *,
         microgrid_id: int,
@@ -147,7 +147,7 @@ class ReportingApiClient:
             * timestamp: The timestamp of the metric sample.
             * value: The metric value.
         """
-        async for page in self._iterate_components_data_pages(
+        async for page in self._list_microgrid_components_data_pages(
             microgrid_components=[(microgrid_id, [component_id])],
             metrics=[metrics] if isinstance(metrics, Metric) else metrics,
             start_dt=start_dt,
@@ -158,7 +158,7 @@ class ReportingApiClient:
                 yield entry
 
     # pylint: disable=too-many-arguments
-    async def _iterate_components_data_pages(
+    async def _list_microgrid_components_data_pages(
         self,
         *,
         microgrid_components: list[tuple[int, list[int]]],


### PR DESCRIPTION
Replace iterator in method names to be closer to gRPC names. 

Raised here https://github.com/frequenz-floss/frequenz-client-reporting-python/pull/16/files#r1548128616.

Naming might not be final.

FYI @llucax 