### PR TITLE
Pin minor version of api dependency to v0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = ">= 3.11, < 4"
 # TODO(cookiecutter): Remove and add more dependencies if appropriate
 dependencies = [
   "typing-extensions >= 4.5.0, < 5",
-  "frequenz-api-reporting >= 0.1.1, < 1",
+  "frequenz-api-reporting >= 0.1.1, < 0.2",
   "frequenz-client-common == 0.1.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Since we allow breaking changes for minor update below v1.0 we cannot expect the client to work with all minor updates.