### PR TITLE
Rename client method to list_microgrid_components_data

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@
 
 ## New Features
 
-* The client method `list_multiple_microgrid_components_data` is added to
+* The client method `list_microgrid_components_data` is added to
 expose the functionality of supporting arbitrary lists of microgrid-component IDs
 and metric IDs. It is intended to be as close as possible on the gRPC function call.
 

--- a/src/frequenz/client/reporting/_client.py
+++ b/src/frequenz/client/reporting/_client.py
@@ -158,7 +158,7 @@ class ReportingApiClient:
                 yield entry
 
     # pylint: disable=too-many-arguments
-    async def list_multiple_microgrid_components_data(
+    async def list_microgrid_components_data(
         self,
         *,
         microgrid_components: list[tuple[int, list[int]]],


### PR DESCRIPTION
Renaming such that the name mirrors the name of the RPC.