### PR TITLE
Update release notes before release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,17 +2,13 @@
 
 ## Summary
 
-<!-- Here goes a general summary of what this release is about -->
-
 ## Upgrading
-
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 ## New Features
 
 * The `ReportingApiClient` exposes the resampling option of the data, with its 
-resolution represented in second and its default set to `None.
+resolution represented in second and its default set to `None`.
+
+* Updated README with usage instructions.
 
 ## Bug Fixes
-
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->


### PR DESCRIPTION
Update before next release that adds resampling option according to https://github.com/frequenz-floss/frequenz-client-reporting-python/blob/v0.x.x/CONTRIBUTING.md#releasing. 