### PR TITLE
Use streaming endpoint in list_microgrid_components_data

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,8 @@
 
 ## Upgrading
 
+* The client now uses the streaming endpoint for historical data requests. The page size parameter is no longer required.
+
 ## New Features
 
 ## Bug Fixes

--- a/src/frequenz/client/reporting/__main__.py
+++ b/src/frequenz/client/reporting/__main__.py
@@ -66,7 +66,6 @@ def main() -> None:
             args.start,
             args.end,
             args.resolution,
-            page_size=args.psize,
             service_address=args.url,
             key=args.key,
             fmt=args.format,
@@ -82,7 +81,6 @@ async def run(
     start_dt: datetime,
     end_dt: datetime,
     resolution: int,
-    page_size: int,
     service_address: str,
     key: str,
     fmt: str,
@@ -96,7 +94,6 @@ async def run(
         start_dt: start datetime
         end_dt: end datetime
         resolution: resampling resolution in sec
-        page_size: page size
         service_address: service address
         key: API key
         fmt: output format
@@ -123,7 +120,6 @@ async def run(
             start_dt=start_dt,
             end_dt=end_dt,
             resolution=resolution,
-            page_size=page_size,
         )
 
     if fmt == "iter":

--- a/tests/test_client_reporting.py
+++ b/tests/test_client_reporting.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from frequenz.client.reporting import ReportingApiClient
-from frequenz.client.reporting._client import ComponentsDataPage
+from frequenz.client.reporting._client import ComponentsDataBatch
 
 
 @pytest.fixture
@@ -25,19 +25,18 @@ async def test_client_initialization(mock_channel: MagicMock) -> None:
     mock_channel.assert_called_once_with("localhost:50051")
 
 
-def test_components_data_page_is_empty_true() -> None:
+def test_components_data_batch_is_empty_true() -> None:
     """Test that the is_empty method returns True when the page is empty."""
     data_pb = MagicMock()
-    data_pb.microgrids = []
-    page = ComponentsDataPage(_data_pb=data_pb)
-    assert page.is_empty() is True
+    data_pb.components = []
+    batch = ComponentsDataBatch(_data_pb=data_pb)
+    assert batch.is_empty() is True
 
 
-def test_components_data_page_is_empty_false() -> None:
+def test_components_data_batch_is_empty_false() -> None:
     """Test that the is_empty method returns False when the page is not empty."""
     data_pb = MagicMock()
-    data_pb.microgrids = [MagicMock()]
-    data_pb.microgrids[0].components = [MagicMock()]
-    data_pb.microgrids[0].components[0].metric_samples = [MagicMock()]
-    page = ComponentsDataPage(_data_pb=data_pb)
-    assert page.is_empty() is False
+    data_pb.components = [MagicMock()]
+    data_pb.components[0].metric_samples = [MagicMock()]
+    batch = ComponentsDataBatch(_data_pb=data_pb)
+    assert batch.is_empty() is False


### PR DESCRIPTION
The streaming endpoint supports requests for historical data. This replaces the list endpoint with the streaming endpoint. The names in the client are for now unchanged to not break user code. They might be revised when live streaming will also be supported by the service.

The list endpoint will most likely be deprecated and removed at some point.