### PR TITLE
Support requesting no metrics in CLI tools

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,7 @@
 
 ## New Features
 
+* The CLI tool supports requesting component states without metrics.
 
 ## Bug Fixes
 

--- a/src/frequenz/client/reporting/__main__.py
+++ b/src/frequenz/client/reporting/__main__.py
@@ -29,10 +29,11 @@ def main() -> None:
     parser.add_argument(
         "--metrics",
         type=str,
-        nargs="+",
+        nargs="*",
         choices=[e.name for e in Metric],
         help="List of metrics to process",
-        required=True,
+        required=False,
+        default=[],
     )
     parser.add_argument(
         "--states",


### PR DESCRIPTION
The service will soon support requesting component states without a metric. This adds support for this feature in the CLI tool.