### PR TITLE
Upgrade to reporting API v0.5

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,10 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+This update comes with a breaking change, that originates from a breaking change in the API specs. Specifically:
+* This and later versions of the client can only be used with the latest reporting API service >=v0.7 but not with older versions of the service.
+* Older versions of the client can only be used with the reporting API service versions < v0.7 but no later versions.
+To ensure compatibility, both the client and service must be updated simultaneously.
 
 ## New Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,11 @@ requires-python = ">= 3.11, < 4"
 dependencies = [
   "typing_extensions >= 4.6.1, < 5",
   "grpc-stubs == 1.53.0.5",
-  "frequenz-api-reporting >= 0.2.0, < 0.5",
+  "frequenz-api-reporting >= 0.5.0, < 0.6",
   "frequenz-client-common >= 0.2.0, < 0.3",
-  "grpcio >= 1.54.2, < 2",
-  "grpcio-tools >= 1.54.2, < 2",
-  "protobuf >= 4.25.3, < 6",
+  "grpcio >=1.66.1, < 2",
+  "grpcio-tools >=1.66.1, < 2",
+  "protobuf >=5.28.2, < 6",
   "frequenz-client-base >= 0.8.0, < 0.9.0",
 ]
 dynamic = ["version"]

--- a/src/frequenz/client/reporting/_client.py
+++ b/src/frequenz/client/reporting/_client.py
@@ -17,6 +17,9 @@ from frequenz.api.common.v1.microgrid.microgrid_pb2 import (
 )
 from frequenz.api.reporting.v1.reporting_pb2 import IncludeOptions as PBIncludeOptions
 from frequenz.api.reporting.v1.reporting_pb2 import (
+    MetricConnections as PBMetricConnections,
+)
+from frequenz.api.reporting.v1.reporting_pb2 import (
     ReceiveMicrogridComponentsDataStreamRequest as PBReceiveMicrogridComponentsDataStreamRequest,
 )
 from frequenz.api.reporting.v1.reporting_pb2 import (
@@ -65,6 +68,7 @@ class ComponentsDataBatch:
             return True
         return False
 
+    # pylint: disable=too-many-locals
     def __iter__(self) -> Iterator[MetricSample]:
         """Get generator that iterates over all values in the batch.
 
@@ -317,11 +321,17 @@ class ReportingApiClient(BaseApiClient[ReportingStub]):
             include_options=include_options,
         )
 
-        metrics_pb = [metric.to_proto() for metric in metrics]
+        metric_conns_pb = [
+            PBMetricConnections(
+                metric=metric.to_proto(),
+                connections=[],
+            )
+            for metric in metrics
+        ]
 
         request = PBReceiveMicrogridComponentsDataStreamRequest(
             microgrid_components=microgrid_components_pb,
-            metrics=metrics_pb,
+            metrics=metric_conns_pb,
             filter=stream_filter,
         )
 


### PR DESCRIPTION
This update includes `MetricConnections` in the request message, that comes with a breaking change in the API specs. To ensure compatibility, both the client and service must be updated simultaneously. Specifically:
* This and later versions of the client can only be used with the latest reporting API service >=v0.7 but not with older versions of the service.
* Older versions of the client can only be used with the reporting API service versions < v0.7 but no later versions.

