### PR TITLE
Support for streaming

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,11 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+* Support for streaming: By omitting the end date in the request,
+  the client will return any historical data from timestamp until now and
+  keep streaming new data as it arrives.
+* Also the start date can be omitted which let's the data start at the
+  earliest time stamp that is available.
 
 ## Bug Fixes
 

--- a/src/frequenz/client/reporting/__main__.py
+++ b/src/frequenz/client/reporting/__main__.py
@@ -49,13 +49,15 @@ def main() -> None:
         "--start",
         type=datetime.fromisoformat,
         help="Start datetime in YYYY-MM-DDTHH:MM:SS format",
-        required=True,
+        required=False,
+        default=None,
     )
     parser.add_argument(
         "--end",
         type=datetime.fromisoformat,
         help="End datetime in YYYY-MM-DDTHH:MM:SS format",
-        required=True,
+        required=False,
+        default=None,
     )
     parser.add_argument(
         "--resampling_period_s",
@@ -97,8 +99,8 @@ async def run(
     microgrid_id: int,
     component_id: int,
     metric_names: list[str],
-    start_dt: datetime,
-    end_dt: datetime,
+    start_dt: datetime | None,
+    end_dt: datetime | None,
     resampling_period_s: int | None,
     states: bool,
     bounds: bool,
@@ -112,8 +114,8 @@ async def run(
         microgrid_id: microgrid ID
         component_id: component ID
         metric_names: list of metric names
-        start_dt: start datetime
-        end_dt: end datetime
+        start_dt: start datetime, if None, the earliest available data will be used
+        end_dt: end datetime, if None starts streaming indefinitely from start_dt
         resampling_period_s: The period for resampling the data.
         states: include states in the output
         bounds: include bounds in the output

--- a/src/frequenz/client/reporting/_client.py
+++ b/src/frequenz/client/reporting/_client.py
@@ -170,8 +170,8 @@ class ReportingApiClient(BaseApiClient[ReportingStub]):
         microgrid_id: int,
         component_id: int,
         metrics: Metric | list[Metric],
-        start_dt: datetime,
-        end_dt: datetime,
+        start_dt: datetime | None,
+        end_dt: datetime | None,
         resampling_period: timedelta | None,
         include_states: bool = False,
         include_bounds: bool = False,
@@ -182,8 +182,8 @@ class ReportingApiClient(BaseApiClient[ReportingStub]):
             microgrid_id: The microgrid ID.
             component_id: The component ID.
             metrics: The metric name or list of metric names.
-            start_dt: The start date and time.
-            end_dt: The end date and time.
+            start_dt: start datetime, if None, the earliest available data will be used
+            end_dt: end datetime, if None starts streaming indefinitely from start_dt
             resampling_period: The period for resampling the data.
             include_states: Whether to include the state data.
             include_bounds: Whether to include the bound data.
@@ -211,8 +211,8 @@ class ReportingApiClient(BaseApiClient[ReportingStub]):
         *,
         microgrid_components: list[tuple[int, list[int]]],
         metrics: Metric | list[Metric],
-        start_dt: datetime,
-        end_dt: datetime,
+        start_dt: datetime | None,
+        end_dt: datetime | None,
         resampling_period: timedelta | None,
         include_states: bool = False,
         include_bounds: bool = False,
@@ -223,8 +223,8 @@ class ReportingApiClient(BaseApiClient[ReportingStub]):
             microgrid_components: List of tuples where each tuple contains
                                   microgrid ID and corresponding component IDs.
             metrics: The metric name or list of metric names.
-            start_dt: The start date and time.
-            end_dt: The end date and time.
+            start_dt: start datetime, if None, the earliest available data will be used
+            end_dt: end datetime, if None starts streaming indefinitely from start_dt
             resampling_period: The period for resampling the data.
             include_states: Whether to include the state data.
             include_bounds: Whether to include the bound data.
@@ -256,8 +256,8 @@ class ReportingApiClient(BaseApiClient[ReportingStub]):
         *,
         microgrid_components: list[tuple[int, list[int]]],
         metrics: list[Metric],
-        start_dt: datetime,
-        end_dt: datetime,
+        start_dt: datetime | None,
+        end_dt: datetime | None,
         resampling_period: timedelta | None,
         include_states: bool = False,
         include_bounds: bool = False,
@@ -270,8 +270,8 @@ class ReportingApiClient(BaseApiClient[ReportingStub]):
         Args:
             microgrid_components: A list of tuples of microgrid IDs and component IDs.
             metrics: A list of metrics.
-            start_dt: The start date and time.
-            end_dt: The end date and time.
+            start_dt: start datetime, if None, the earliest available data will be used
+            end_dt: end datetime, if None starts streaming indefinitely from start_dt
             resampling_period: The period for resampling the data.
             include_states: Whether to include the state data.
             include_bounds: Whether to include the bound data.
@@ -290,8 +290,8 @@ class ReportingApiClient(BaseApiClient[ReportingStub]):
             return ts
 
         time_filter = PBTimeFilter(
-            start=dt2ts(start_dt),
-            end=dt2ts(end_dt),
+            start=dt2ts(start_dt) if start_dt else None,
+            end=dt2ts(end_dt) if end_dt else None,
         )
 
         incl_states = (


### PR DESCRIPTION
This adds support for streaming: By omitting the end date in the request, the client will return any historical data from timestamp until now and keep streaming new data as it arrives.

Also the start date can be omitted which let's the data start at the earliest time stamp that is available.