### PR TITLE
Ensure tz-aware timestamps in response

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
 ## Upgrading
 
 * Update repo-config and setuptools versions
+* Timestamps in the response are now timezone aware.
 
 ## New Features
 

--- a/src/frequenz/client/reporting/_client.py
+++ b/src/frequenz/client/reporting/_client.py
@@ -6,7 +6,7 @@
 from collections import namedtuple
 from collections.abc import AsyncIterator, Iterable, Iterator
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import cast
 
 import grpc.aio as grpcaio
@@ -90,6 +90,9 @@ class ComponentsDataBatch:
             cid = cdata.component_id
             for msample in cdata.metric_samples:
                 ts = msample.sampled_at.ToDatetime()
+                # Ensure tz-aware timestamps,
+                # as the API returns tz-naive UTC timestamps
+                ts = ts.replace(tzinfo=timezone.utc)
                 met = Metric.from_proto(msample.metric).name
                 value = (
                     msample.value.simple_metric.value


### PR DESCRIPTION
The API response contains only tz-naive UTC timestamps, which are converted to tz-aware timestamps to avoid misinterpretation.