### PR TITLE
Add method to receive aggregated data

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,8 @@
 
 ## New Features
 
+* Adds new method `receive_aggregated_data` to receive microgrid component data
+  aggregated by user-defined formulae.
 
 ## Bug Fixes
 


### PR DESCRIPTION
This adds support for the API endpoint to query aggregated data based on user-defined formulae. Latter can be passed by the user as strings (e.g. `#CID1 + #CID2`) as documented in the API specs.

Fixes #24 