### PR TITLE
Ensure timezone-aware timestamps in formula endpoint result

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
 ## Upgrading
 
 * The CLI tool is moved to dedicated folder.
+* Timestamps of aggregated (formula) requests are now timezone-aware.
 
 <!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 

--- a/src/frequenz/client/reporting/_client.py
+++ b/src/frequenz/client/reporting/_client.py
@@ -164,7 +164,9 @@ class AggregatedMetric:
     def sample(self) -> MetricSample:
         """Return the aggregated metric sample."""
         return MetricSample(
-            timestamp=self._data_pb.sample.sampled_at.ToDatetime(),
+            timestamp=self._data_pb.sample.sampled_at.ToDatetime().replace(
+                tzinfo=timezone.utc
+            ),
             microgrid_id=self._data_pb.aggregation_config.microgrid_id,
             component_id=self._data_pb.aggregation_config.aggregation_formula,
             metric=self._data_pb.aggregation_config.metric,


### PR DESCRIPTION
Required since the service responds with naive timestamps in UTC.