### PR TITLE
Take grpcio-tools out of dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
   "frequenz-api-reporting >= 0.7.0, < 0.8",
   "frequenz-client-common >= 0.3.0, < 0.4",
   "grpcio >=1.70.0, < 2",
-  "grpcio-tools >=1.70.0, < 2",
   "protobuf >=5.29.3, < 6",
   "frequenz-client-base >= 0.8.0, < 0.10.0",
 ]


### PR DESCRIPTION
Follow up on pinning grpc dependency issue in [PR](https://github.com/frequenz-floss/frequenz-api-reporting/pull/87).