### PR TITLE
Add Dependabot Auto Manage workflow

### DIFF
--- a/.github/workflows/auto-dependabot.yaml
+++ b/.github/workflows/auto-dependabot.yaml
@@ -1,0 +1,20 @@
+name: Dependabot Auto Manage
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: ad/dependabot-auto-approve@v1
+        with:
+          dependency-type: 'all'
+          auto-merge: 'true'
+          merge-method: 'merge'
+          add-label: 'auto-merged'


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to automatically approve and merge Dependabot PRs
- Uses ad/dependabot-auto-approve action with merge method
- Applies to all dependency types and adds 'auto-merged' label