### PR TITLE
Fix aggregated values for missing data

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,13 +2,11 @@
 
 ## Summary
 
-> **Warning:** This client is compatible *only* with Reporting API `v1alpha10` or later.
-> Using with services that use an older API version **will cause failures**.
+<!-- Here goes a general summary of what this release is about -->
 
 ## Upgrading
 
-* Breaking change to reporting API v1alpha10.
-* Switch to new `metrics` package from client-common.
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 ## New Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+* Fix default value of formula-aggregated metrics when no data was sent.

--- a/src/frequenz/client/reporting/_types.py
+++ b/src/frequenz/client/reporting/_types.py
@@ -3,6 +3,7 @@
 
 """Types for the Reporting API client."""
 
+import math
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from datetime import datetime
@@ -180,10 +181,25 @@ class AggregatedMetric:
 
     def sample(self) -> MetricSample:
         """Return the aggregated metric sample."""
-        return MetricSample(
-            timestamp=datetime_from_proto(self._data_pb.sample.sample_time),
-            microgrid_id=self._data_pb.aggregation_config.microgrid_id,
-            component_id=self._data_pb.aggregation_config.aggregation_formula,
-            metric=Metric(self._data_pb.aggregation_config.metric).name,
-            value=self._data_pb.sample.sample.value,
+        config = self._data_pb.aggregation_config
+        sample = self._data_pb.sample
+
+        timestamp = datetime_from_proto(sample.sample_time)
+        microgrid_id = config.microgrid_id
+        component_id = config.aggregation_formula
+        metric = Metric(config.metric).name
+        # Ignoring this verification results in
+        # values of zero if the field is not set.
+        if sample.HasField("sample") and sample.sample.HasField("value"):
+            value = sample.sample.value
+        else:
+            value = math.nan
+
+        ret = MetricSample(
+            timestamp=timestamp,
+            microgrid_id=microgrid_id,
+            component_id=component_id,
+            metric=metric,
+            value=value,
         )
+        return ret


### PR DESCRIPTION
If the samples in the protobuf of the aggregated response has the value not set (e.g. when the service sends None values), the generated python code falls back to zeroes when the field is accessed. This case needs to be handled explicitly by the client, which now sets these values to NaN.