### PR TITLE
Remove invalid HasField check on proto3 scalar metric value

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-* Fix default value of formula-aggregated metrics when no data was sent.
+* Remove invalid HasField check on scalar which can cause failure retrieving formula-aggregated metrics.

--- a/src/frequenz/client/reporting/_types.py
+++ b/src/frequenz/client/reporting/_types.py
@@ -190,7 +190,7 @@ class AggregatedMetric:
         metric = Metric(config.metric).name
         # Ignoring this verification results in
         # values of zero if the field is not set.
-        if sample.HasField("sample") and sample.sample.HasField("value"):
+        if sample.HasField("sample"):
             value = sample.sample.value
         else:
             value = math.nan


### PR DESCRIPTION
Scalar fields do not have HasField check in proto3.