### PR TITLE
Simplify install instructions and add plotting example

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,34 @@ df = pd.DataFrame(data)
 print(df)
 ```
 
+## Plotting data with matplotlib
+
+```bash
+pip install matplotlib
+```
+
+Using the `data` variable from any of the examples above:
+
+```python
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+
+timestamps = [s.timestamp for s in data]
+values = [s.value for s in data]
+
+fig, ax = plt.subplots(figsize=(14, 5))
+ax.plot(timestamps, values)
+
+# Optional: customize the plot
+ax.set_title("AC Active Power")
+ax.set_ylabel("Power (W)")
+ax.xaxis.set_major_formatter(mdates.DateFormatter("%H:%M"))
+ax.grid(True)
+fig.tight_layout()
+
+plt.show()
+```
+
 ## Command line client tool
 
 The package contains a command-line tool that can be used to request
@@ -220,39 +248,3 @@ reporting-cli \
     --bounds
 ```
 In addition to the default CSV format, individual samples can also be output using the `--format iter` option.
-
-## Plotting data with matplotlib
-
-```bash
-pip install matplotlib
-```
-
-```python
-import matplotlib.pyplot as plt
-import matplotlib.dates as mdates
-
-# Fetch data (see examples above)
-data = [
-    sample async for sample in
-    client.receive_single_component_data(
-        microgrid_id=1,
-        component_id=100,
-        metrics=[Metric.AC_ACTIVE_POWER],
-        start_time=datetime.fromisoformat("2024-05-01T00:00:00"),
-        end_time=datetime.fromisoformat("2024-05-02T00:00:00"),
-        resampling_period=timedelta(seconds=60),
-    )
-]
-
-timestamps = [s.timestamp for s in data]
-values = [s.value for s in data]
-
-fig, ax = plt.subplots(figsize=(14, 5))
-ax.plot(timestamps, values)
-ax.set_title("AC Active Power")
-ax.set_ylabel("Power (W)")
-ax.xaxis.set_major_formatter(mdates.DateFormatter("%H:%M"))
-ax.grid(True)
-fig.tight_layout()
-plt.show()
-```

--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ In addition to the default CSV format, individual samples can also be output usi
 
 ## Plotting data with matplotlib
 
+```bash
+pip install matplotlib
+```
+
 ```python
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates

--- a/README.md
+++ b/README.md
@@ -34,9 +34,7 @@ for a practical example of how to use the client.
 ### Installation
 
 ```bash
-# Choose the version you want to install
-VERSION=0.18.0
-pip install frequenz-client-reporting==$VERSION
+pip install frequenz-client-reporting
 ```
 
 
@@ -222,3 +220,35 @@ reporting-cli \
     --bounds
 ```
 In addition to the default CSV format, individual samples can also be output using the `--format iter` option.
+
+## Plotting data with matplotlib
+
+```python
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+
+# Fetch data (see examples above)
+data = [
+    sample async for sample in
+    client.receive_single_component_data(
+        microgrid_id=1,
+        component_id=100,
+        metrics=[Metric.AC_ACTIVE_POWER],
+        start_time=datetime.fromisoformat("2024-05-01T00:00:00"),
+        end_time=datetime.fromisoformat("2024-05-02T00:00:00"),
+        resampling_period=timedelta(seconds=60),
+    )
+]
+
+timestamps = [s.timestamp for s in data]
+values = [s.value for s in data]
+
+fig, ax = plt.subplots(figsize=(14, 5))
+ax.plot(timestamps, values)
+ax.set_title("AC Active Power")
+ax.set_ylabel("Power (W)")
+ax.xaxis.set_major_formatter(mdates.DateFormatter("%H:%M"))
+ax.grid(True)
+fig.tight_layout()
+plt.show()
+```


### PR DESCRIPTION
Remove the hardcoded version from the pip install command — users should just install the latest by default.

Add a matplotlib plotting example at the end of the README showing how to visualize fetched data.