### PR TITLE
Fix responses with bounds

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-* Remove invalid HasField check on scalar which can cause failure retrieving formula-aggregated metrics.
+* Fixes a bug where bounds of 0 were ignored and ensure the client always returns a pair of upper and lower bounds, were unset bounds are represented by +/- infinity.

--- a/src/frequenz/client/reporting/_types.py
+++ b/src/frequenz/client/reporting/_types.py
@@ -119,14 +119,14 @@ class GenericDataBatch:
 
                 if self.has_bounds:
                     for i, bound in enumerate(sample.bounds):
-                        if bound.lower:
-                            yield MetricSample(
-                                ts, mid, cid, f"{met}_bound_{i}_lower", bound.lower
-                            )
-                        if bound.upper:
-                            yield MetricSample(
-                                ts, mid, cid, f"{met}_bound_{i}_upper", bound.upper
-                            )
+                        lower = bound.lower if bound.HasField("lower") else -math.inf
+                        yield MetricSample(
+                            ts, mid, cid, f"{met}_bound_{i}_lower", lower
+                        )
+                        upper = bound.upper if bound.HasField("upper") else math.inf
+                        yield MetricSample(
+                            ts, mid, cid, f"{met}_bound_{i}_upper", upper
+                        )
 
             for state in getattr(item, "state_snapshots", []):
                 ts = datetime_from_proto(state.origin_time)


### PR DESCRIPTION
Fixes a bug where bounds of zero were ignored. Also ensures that we always return a pair of upper and lower bounds, where +/-inf is returned in case the bound is not set.