### PR TITLE
Typing improvements

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- `MetricSample` values now have correct type-hints.
 
 ## New Features
 

--- a/src/frequenz/client/reporting/_types.py
+++ b/src/frequenz/client/reporting/_types.py
@@ -10,6 +10,15 @@ from datetime import datetime
 from typing import Generic, NamedTuple, Protocol, TypeVar
 
 # pylint: disable=no-name-in-module
+from frequenz.api.common.v1alpha8.metrics.metrics_pb2 import (
+    MetricSample as PbMetricSample,
+)
+from frequenz.api.common.v1alpha8.microgrid.electrical_components.electrical_components_pb2 import (
+    ElectricalComponentTelemetry as PbElectricalComponentTelemetry,
+)
+from frequenz.api.common.v1alpha8.microgrid.sensors.sensors_pb2 import (
+    SensorTelemetry as PbSensorTelemetry,
+)
 from frequenz.api.reporting.v1alpha10.reporting_pb2 import (
     ReceiveAggregatedMicrogridComponentsDataStreamResponse as PBAggregatedStreamResponse,
 )
@@ -48,12 +57,20 @@ class _PbMgTelem(Protocol):
         """Return the microgrid ID of the telemetry batch."""
 
 
+class _PbTelem(Protocol):
+    """Protocol for telemetry items in the Reporting API client."""
+
+    @property
+    def metric_samples(self) -> MutableSequence[PbMetricSample]:
+        """Return the metric samples of the telemetry item."""
+
 
 _MgTelemT = TypeVar("_MgTelemT", bound=_PbMgTelem)
+_TelemT = TypeVar("_TelemT", bound=_PbTelem)
 
 
 @dataclass(frozen=True)
-class GenericDataBatch(Generic[_MgTelemT]):
+class GenericDataBatch(Generic[_MgTelemT, _TelemT]):
     """Base class for batches of microgrid data (components or sensors).
 
     This class serves as a base for handling batches of data related to microgrid
@@ -77,9 +94,7 @@ class GenericDataBatch(Generic[_MgTelemT]):
         if not items:
             return True
         for item in items:
-            if not getattr(item, "metric_samples", []) and not getattr(
-                item, "states", []
-            ):
+            if not item.metric_samples and not getattr(item, "states", []):
                 return True
         return False
 
@@ -105,7 +120,7 @@ class GenericDataBatch(Generic[_MgTelemT]):
 
         for item in items:
             cid = getattr(item, self.id_attr)
-            for sample in getattr(item, "metric_samples", []):
+            for sample in item.metric_samples:
                 ts = datetime_from_proto(sample.sample_time)
                 met = enum_from_proto(sample.metric, Metric, allow_invalid=False).name
 
@@ -155,7 +170,9 @@ class GenericDataBatch(Generic[_MgTelemT]):
 
 @dataclass(frozen=True)
 class ComponentsDataBatch(
-    GenericDataBatch[PBReceiveMicrogridComponentsDataStreamResponse]
+    GenericDataBatch[
+        PBReceiveMicrogridComponentsDataStreamResponse, PbElectricalComponentTelemetry
+    ]
 ):
     """Batch of microgrid components data."""
 
@@ -174,7 +191,9 @@ class ComponentsDataBatch(
 
 
 @dataclass(frozen=True)
-class SensorsDataBatch(GenericDataBatch[PBReceiveMicrogridSensorsDataStreamResponse]):
+class SensorsDataBatch(
+    GenericDataBatch[PBReceiveMicrogridSensorsDataStreamResponse, PbSensorTelemetry]
+):
     """Batch of microgrid sensors data."""
 
     def __init__(self, data_pb: PBReceiveMicrogridSensorsDataStreamResponse):

--- a/src/frequenz/client/reporting/_types.py
+++ b/src/frequenz/client/reporting/_types.py
@@ -44,7 +44,7 @@ class MetricSample(NamedTuple):
 
     timestamp: datetime
     microgrid_id: int
-    component_id: str
+    component_id: int | str
     metric: str
     value: float
 
@@ -80,7 +80,7 @@ class GenericDataBatch(Generic[_MgTelemT, _TelemT]):
     """
 
     _data_pb: _MgTelemT
-    id_attr: str
+    id_fetcher: Callable[[_TelemT], int]
     items_fetcher: Callable[[_MgTelemT], MutableSequence[_TelemT]]
     has_bounds: bool = False
 
@@ -119,7 +119,7 @@ class GenericDataBatch(Generic[_MgTelemT, _TelemT]):
         items = self.items_fetcher(self._data_pb)
 
         for item in items:
-            cid = getattr(item, self.id_attr)
+            cid = self.id_fetcher(item)
             for sample in item.metric_samples:
                 ts = datetime_from_proto(sample.sample_time)
                 met = enum_from_proto(sample.metric, Metric, allow_invalid=False).name
@@ -184,7 +184,7 @@ class ComponentsDataBatch(
         """
         super().__init__(
             data_pb,
-            id_attr="electrical_component_id",
+            id_fetcher=lambda item: item.electrical_component_id,
             items_fetcher=lambda pb: pb.components,
             has_bounds=True,
         )
@@ -204,7 +204,7 @@ class SensorsDataBatch(
         """
         super().__init__(
             data_pb,
-            id_attr="sensor_id",
+            id_fetcher=lambda item: item.sensor_id,
             items_fetcher=lambda pb: pb.sensors,
         )
 

--- a/src/frequenz/client/reporting/_types.py
+++ b/src/frequenz/client/reporting/_types.py
@@ -7,7 +7,7 @@ import math
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, NamedTuple
+from typing import Generic, NamedTuple, Protocol, TypeVar
 
 # pylint: disable=no-name-in-module
 from frequenz.api.reporting.v1alpha10.reporting_pb2 import (
@@ -40,8 +40,20 @@ class MetricSample(NamedTuple):
     value: float
 
 
+class _PbMgTelem(Protocol):
+    """Protocol for microgrid telemetry from the Reporting API client."""
+
+    @property
+    def microgrid_id(self) -> int:
+        """Return the microgrid ID of the telemetry batch."""
+
+
+
+_MgTelemT = TypeVar("_MgTelemT", bound=_PbMgTelem)
+
+
 @dataclass(frozen=True)
-class GenericDataBatch:
+class GenericDataBatch(Generic[_MgTelemT]):
     """Base class for batches of microgrid data (components or sensors).
 
     This class serves as a base for handling batches of data related to microgrid
@@ -50,7 +62,7 @@ class GenericDataBatch:
     functionality to work with bounds if applicable.
     """
 
-    _data_pb: Any
+    _data_pb: _MgTelemT
     id_attr: str
     items_attr: str
     has_bounds: bool = False
@@ -142,7 +154,9 @@ class GenericDataBatch:
 
 
 @dataclass(frozen=True)
-class ComponentsDataBatch(GenericDataBatch):
+class ComponentsDataBatch(
+    GenericDataBatch[PBReceiveMicrogridComponentsDataStreamResponse]
+):
     """Batch of microgrid components data."""
 
     def __init__(self, data_pb: PBReceiveMicrogridComponentsDataStreamResponse):
@@ -160,7 +174,7 @@ class ComponentsDataBatch(GenericDataBatch):
 
 
 @dataclass(frozen=True)
-class SensorsDataBatch(GenericDataBatch):
+class SensorsDataBatch(GenericDataBatch[PBReceiveMicrogridSensorsDataStreamResponse]):
     """Batch of microgrid sensors data."""
 
     def __init__(self, data_pb: PBReceiveMicrogridSensorsDataStreamResponse):

--- a/src/frequenz/client/reporting/_types.py
+++ b/src/frequenz/client/reporting/_types.py
@@ -73,7 +73,7 @@ class MetricSample(NamedTuple):
     )
 
 
-class _PbMgTelem(Protocol):
+class _PbMicrogridTelem(Protocol):
     """Protocol for microgrid telemetry from the Reporting API client."""
 
     @property
@@ -81,7 +81,7 @@ class _PbMgTelem(Protocol):
         """Return the microgrid ID of the telemetry batch."""
 
 
-class _PbTelem(Protocol):
+class _PbComponentTelem(Protocol):
     """Protocol for telemetry items in the Reporting API client."""
 
     @property
@@ -93,15 +93,15 @@ class _PbTelem(Protocol):
         """List of state snapshots associated with this telemetry item."""
 
 
-_MgTelemT = TypeVar("_MgTelemT", bound=_PbMgTelem)
-_TelemT = TypeVar("_TelemT", bound=_PbTelem)
+_MicrogridTelemT = TypeVar("_MicrogridTelemT", bound=_PbMicrogridTelem)
+_ComponentTelemT = TypeVar("_ComponentTelemT", bound=_PbComponentTelem)
 _StateSnapshotT = TypeVar(
     "_StateSnapshotT", bound=PbElectricalComponentStateSnapshot | PbSensorStateSnapshot
 )
 
 
 @dataclass(frozen=True)
-class GenericDataBatch(Generic[_MgTelemT, _TelemT, _StateSnapshotT]):
+class GenericDataBatch(Generic[_MicrogridTelemT, _ComponentTelemT, _StateSnapshotT]):
     """Base class for batches of microgrid data (components or sensors).
 
     This class serves as a base for handling batches of data related to microgrid
@@ -110,9 +110,9 @@ class GenericDataBatch(Generic[_MgTelemT, _TelemT, _StateSnapshotT]):
     functionality to work with bounds if applicable.
     """
 
-    _data_pb: _MgTelemT
-    id_fetcher: Callable[[_TelemT], int]
-    items_fetcher: Callable[[_MgTelemT], MutableSequence[_TelemT]]
+    _data_pb: _MicrogridTelemT
+    id_fetcher: Callable[[_ComponentTelemT], int]
+    items_fetcher: Callable[[_MicrogridTelemT], MutableSequence[_ComponentTelemT]]
     has_bounds: bool = False
 
     def is_empty(self) -> bool:

--- a/src/frequenz/client/reporting/_types.py
+++ b/src/frequenz/client/reporting/_types.py
@@ -4,17 +4,35 @@
 """Types for the Reporting API client."""
 
 import math
-from collections.abc import Iterable, Iterator, MutableSequence
+from collections.abc import Iterator, MutableSequence
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Callable, Generic, NamedTuple, Protocol, TypeVar
+from typing import Any, Callable, Generic, NamedTuple, Protocol, TypeVar, cast
 
 # pylint: disable=no-name-in-module
 from frequenz.api.common.v1alpha8.metrics.metrics_pb2 import (
     MetricSample as PbMetricSample,
 )
 from frequenz.api.common.v1alpha8.microgrid.electrical_components.electrical_components_pb2 import (
+    ElectricalComponentDiagnostic as PbElectricalComponentDiagnostic,
+)
+from frequenz.api.common.v1alpha8.microgrid.electrical_components.electrical_components_pb2 import (
+    ElectricalComponentStateCode as PbElectricalComponentStateCode,
+)
+from frequenz.api.common.v1alpha8.microgrid.electrical_components.electrical_components_pb2 import (
+    ElectricalComponentStateSnapshot as PbElectricalComponentStateSnapshot,
+)
+from frequenz.api.common.v1alpha8.microgrid.electrical_components.electrical_components_pb2 import (
     ElectricalComponentTelemetry as PbElectricalComponentTelemetry,
+)
+from frequenz.api.common.v1alpha8.microgrid.sensors.sensors_pb2 import (
+    SensorDiagnostic as PbSensorDiagnostic,
+)
+from frequenz.api.common.v1alpha8.microgrid.sensors.sensors_pb2 import (
+    SensorStateCode as PbSensorStateCode,
+)
+from frequenz.api.common.v1alpha8.microgrid.sensors.sensors_pb2 import (
+    SensorStateSnapshot as PbSensorStateSnapshot,
 )
 from frequenz.api.common.v1alpha8.microgrid.sensors.sensors_pb2 import (
     SensorTelemetry as PbSensorTelemetry,
@@ -46,7 +64,13 @@ class MetricSample(NamedTuple):
     microgrid_id: int
     component_id: int | str
     metric: str
-    value: float
+    value: (
+        float
+        | PbElectricalComponentStateCode.ValueType
+        | PbSensorStateCode.ValueType
+        | PbElectricalComponentDiagnostic
+        | PbSensorDiagnostic
+    )
 
 
 class _PbMgTelem(Protocol):
@@ -64,13 +88,20 @@ class _PbTelem(Protocol):
     def metric_samples(self) -> MutableSequence[PbMetricSample]:
         """Return the metric samples of the telemetry item."""
 
+    @property
+    def state_snapshots(self) -> MutableSequence[Any]:
+        """List of state snapshots associated with this telemetry item."""
+
 
 _MgTelemT = TypeVar("_MgTelemT", bound=_PbMgTelem)
 _TelemT = TypeVar("_TelemT", bound=_PbTelem)
+_StateSnapshotT = TypeVar(
+    "_StateSnapshotT", bound=PbElectricalComponentStateSnapshot | PbSensorStateSnapshot
+)
 
 
 @dataclass(frozen=True)
-class GenericDataBatch(Generic[_MgTelemT, _TelemT]):
+class GenericDataBatch(Generic[_MgTelemT, _TelemT, _StateSnapshotT]):
     """Base class for batches of microgrid data (components or sensors).
 
     This class serves as a base for handling batches of data related to microgrid
@@ -94,9 +125,9 @@ class GenericDataBatch(Generic[_MgTelemT, _TelemT]):
         if not items:
             return True
         for item in items:
-            if not item.metric_samples and not getattr(item, "states", []):
-                return True
-        return False
+            if item.metric_samples or item.state_snapshots:
+                return False
+        return True
 
     # pylint: disable=too-many-locals
     # pylint: disable=too-many-branches
@@ -155,15 +186,14 @@ class GenericDataBatch(Generic[_MgTelemT, _TelemT]):
                             ts, mid, cid, f"{met}_bound_{i}_upper", upper
                         )
 
-            for state in getattr(item, "state_snapshots", []):
+            for state in item.state_snapshots:
+                state = cast(_StateSnapshotT, state)
                 ts = datetime_from_proto(state.origin_time)
                 for category, category_items in {
-                    "state": getattr(state, "states", []),
-                    "warning": getattr(state, "warnings", []),
-                    "error": getattr(state, "errors", []),
+                    "state": state.states,
+                    "warning": state.warnings,
+                    "error": state.errors,
                 }.items():
-                    if not isinstance(category_items, Iterable):
-                        continue
                     for s in category_items:
                         yield MetricSample(ts, mid, cid, category, s)
 
@@ -171,7 +201,9 @@ class GenericDataBatch(Generic[_MgTelemT, _TelemT]):
 @dataclass(frozen=True)
 class ComponentsDataBatch(
     GenericDataBatch[
-        PBReceiveMicrogridComponentsDataStreamResponse, PbElectricalComponentTelemetry
+        PBReceiveMicrogridComponentsDataStreamResponse,
+        PbElectricalComponentTelemetry,
+        PbElectricalComponentStateSnapshot,
     ]
 ):
     """Batch of microgrid components data."""
@@ -192,7 +224,11 @@ class ComponentsDataBatch(
 
 @dataclass(frozen=True)
 class SensorsDataBatch(
-    GenericDataBatch[PBReceiveMicrogridSensorsDataStreamResponse, PbSensorTelemetry]
+    GenericDataBatch[
+        PBReceiveMicrogridSensorsDataStreamResponse,
+        PbSensorTelemetry,
+        PbSensorStateSnapshot,
+    ]
 ):
     """Batch of microgrid sensors data."""
 

--- a/src/frequenz/client/reporting/_types.py
+++ b/src/frequenz/client/reporting/_types.py
@@ -4,10 +4,10 @@
 """Types for the Reporting API client."""
 
 import math
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, MutableSequence
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Generic, NamedTuple, Protocol, TypeVar
+from typing import Callable, Generic, NamedTuple, Protocol, TypeVar
 
 # pylint: disable=no-name-in-module
 from frequenz.api.common.v1alpha8.metrics.metrics_pb2 import (
@@ -81,7 +81,7 @@ class GenericDataBatch(Generic[_MgTelemT, _TelemT]):
 
     _data_pb: _MgTelemT
     id_attr: str
-    items_attr: str
+    items_fetcher: Callable[[_MgTelemT], MutableSequence[_TelemT]]
     has_bounds: bool = False
 
     def is_empty(self) -> bool:
@@ -90,7 +90,7 @@ class GenericDataBatch(Generic[_MgTelemT, _TelemT]):
         Returns:
             True if the batch contains no valid data.
         """
-        items = getattr(self._data_pb, self.items_attr, [])
+        items = self.items_fetcher(self._data_pb)
         if not items:
             return True
         for item in items:
@@ -116,7 +116,7 @@ class GenericDataBatch(Generic[_MgTelemT, _TelemT]):
             * value: The metric value.
         """
         mid = self._data_pb.microgrid_id
-        items = getattr(self._data_pb, self.items_attr)
+        items = self.items_fetcher(self._data_pb)
 
         for item in items:
             cid = getattr(item, self.id_attr)
@@ -185,7 +185,7 @@ class ComponentsDataBatch(
         super().__init__(
             data_pb,
             id_attr="electrical_component_id",
-            items_attr="components",
+            items_fetcher=lambda pb: pb.components,
             has_bounds=True,
         )
 
@@ -202,7 +202,11 @@ class SensorsDataBatch(
         Args:
             data_pb: The underlying protobuf message.
         """
-        super().__init__(data_pb, id_attr="sensor_id", items_attr="sensors")
+        super().__init__(
+            data_pb,
+            id_attr="sensor_id",
+            items_fetcher=lambda pb: pb.sensors,
+        )
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Earlier there were a number of `getattr` that was hiding the actual types of values going into `MetricSample`s.  This PR replaces all such instances, so that only strongly typed values go into `MetricSample`s.