### PR TITLE
Quote CSV fields containing commas in CLI output

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+* The CLI's CSV output now quotes fields containing commas, so aggregation formulae in the `component_id` column no longer break the CSV structure.

--- a/src/frequenz/client/reporting/cli/__main__.py
+++ b/src/frequenz/client/reporting/cli/__main__.py
@@ -5,6 +5,8 @@
 
 import argparse
 import asyncio
+import csv
+import sys
 from datetime import datetime, timedelta
 from typing import AsyncIterator
 
@@ -198,11 +200,14 @@ async def run(  # noqa: DOC502
             print(sample)
 
     elif fmt == "csv":
-        # Print header
-        print(",".join(MetricSample._fields))
-        # Iterate over single metric generator and format as CSV
+        # Use the csv module so fields containing commas (e.g. aggregation
+        # formulae in component_id) are quoted per RFC 4180. Keep the LF line
+        # terminator the previous print()-based output used (csv defaults to
+        # CRLF).
+        writer = csv.writer(sys.stdout, lineterminator="\n")
+        writer.writerow(MetricSample._fields)
         async for sample in data_iter():
-            print(",".join(str(e) for e in sample))
+            writer.writerow(sample)
 
     else:
         raise ValueError(f"Invalid output format: {fmt}")


### PR DESCRIPTION
The CLI's `csv` output built each row with `",".join(...)`, which never quotes fields. An aggregation formula in the `component_id` column (e.g. `COALESCE(#396, 0.0) + COALESCE(#397, 0.0)`) contains commas, so it spilled into extra columns and produced malformed CSV that breaks downstream parsers like csvm. This switches the output to Python's `csv` module so such fields are quoted per RFC 4180.

## Changes
- CSV output now uses `csv.writer` instead of manual `",".join(...)`, quoting any field containing commas.
- Pin the line terminator to `\n` so output stays LF (the `csv` module defaults to CRLF), matching the previous `print()`-based behavior.